### PR TITLE
Bump prompt-toolkit to 3.0.43 

### DIFF
--- a/scripts/constraints.txt
+++ b/scripts/constraints.txt
@@ -189,7 +189,7 @@ prettytable==2.5.0
     # via
     #   mbed-ls
     #   mbed-os-tools
-prompt-toolkit==3.0.26
+prompt-toolkit==3.0.43
     # via ipython
 protobuf==3.17.3
     # via -r requirements.txt


### PR DESCRIPTION
Bump prompt-toolkit to 3.0.43 to fix this error: `ImportError: cannot import name 'OneStyleAndTextTuple' from 'prompt_toolkit.formatted_text' `
Fixes #140.

Already fixed in connectedhomeip repo: [constraints.txt](https://github.com/project-chip/connectedhomeip/blob/d8f5bf1a41d1cfb19a5a1fdd342b85c4dfb842ea/scripts/setup/constraints.txt#L166).