### PR TITLE
fix_uart_log_and_icd_and_bootloader_link

### DIFF
--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -223,7 +223,7 @@ source_set("efr32-common") {
     "${silabs_common_plat_dir}/syscalls_stubs.cpp",
   ]
 
-  if (chip_enable_pw_rpc || chip_build_libshell || enable_openthread_cli) {
+  if (chip_enable_pw_rpc || chip_build_libshell || enable_openthread_cli || sl_uart_log_output) {
     sources += [ "uart.cpp" ]
   }
 

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -195,7 +195,7 @@ else
                 shift
                 ;;
             --icd)
-                optArgs+="chip_enable_icd_server=true chip_openthread_ftd=false "
+                optArgs+="chip_enable_icd_server=true chip_enable_icd_lit=true chip_openthread_ftd=false "
                 shift
                 ;;
             --low-power)
@@ -376,7 +376,7 @@ else
         fi
 
         # search bootloader directory for the respective bootloaders for the input board
-        bootloaderFiles=("$(find "$MATTER_ROOT/third_party/silabs/matter_support/matter/efr32/bootloader_binaries/" -maxdepth 1 -name "*$SILABS_BOARD*" | tr '\n' ' ')")
+	bootloaderFiles=($(find "$MATTER_ROOT/third_party/silabs/matter_support/matter/efr32/bootloader_binaries/" -maxdepth 1 -name "*$SILABS_BOARD*" | tr '\n' ' '))
 
         if [ "${#bootloaderFiles[@]}" -gt 1 ]; then
             for i in "${!bootloaderFiles[@]}"; do
@@ -394,6 +394,7 @@ else
         echo "$bootloaderPath"
         binName="$(find "$BUILD_DIR" -type f -name "*.s37")"
         echo "$binName"
-        "$commanderPath" convert "$binName" "$bootloaderPath" -o "$binName"
+	binNameWithoutExt="${binName%.*}"
+        "$commanderPath" convert "$binName" "$bootloaderPath" -o "${binNameWithoutExt}-with-bootloader.hex"
     fi
 fi


### PR DESCRIPTION
1. fixed the undefined compile error of `uartConsoleInit` caused by not including `uart.cpp` when `--uart_log` parameter is enabled.
2. fixed the undefined compilation error of `emberAfIcdManagementClusterRegisterClientCallback` and `emberAfIcdManagementClusterUnregisterClientCallback` when ICD is enabled.
3. Fix the problem that the `bootloaderFiles` array was defined incorrectly and the corresponding bootloader could not be found.
4. When passing `--bootloader` parameter, generate merge file with suffix in hex format, so as to avoid the failure of merging the same file by repeating the allow command.

test command:
```
./scripts/examples/gn_silabs_example.sh ./examples/smoke-co-alarm-app/silabs ./out BRD4187C --icd --low-power --bootloader --uart_log
```

I sincerely hope you can merge this fix into the upstream community repository as well.